### PR TITLE
Fix: Add OIDC permissions to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       # Define IMAGE_NAME at the job level to handle potential parsing issues with toLowerCase() in global env.
       # github.event.repository.name is converted to lowercase for the image name.


### PR DESCRIPTION
The GitHub Actions workflow for building and publishing the Docker image was failing due to missing permissions required for generating an ID token. This is necessary for the artifact attestation step (`actions/attest-build-provenance@v2`).

This commit adds the following permissions to the `build-and-push` job:
- `id-token: write`: Allows the job to request an OpenID Connect (OIDC) token.
- `contents: read`: Grants read access to the repository contents, which is a safe default.

These changes should resolve the "Failed to get ID token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable" error.

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

[Briefly describe the changes made in this pull request.]

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

[List the specific changes made in this pull request.]

## Checklist

- [ ] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
